### PR TITLE
fix: correct defer strategy for critical JavaScript dependencies

### DIFF
--- a/gallery_html/belton_house.html
+++ b/gallery_html/belton_house.html
@@ -127,11 +127,11 @@
   </div>
 
   <!-- for lateral navbar-->
-  <script src="../js/jquery-3.3.1.min.js" defer></script>
-  <script src="../js/jquery-migrate-3.0.1.min.js" defer></script>
+  <script src="../js/jquery-3.3.1.min.js"></script>
+  <script src="../js/jquery-migrate-3.0.1.min.js"></script>
   <script src="../js/jquery-ui.js" defer></script>
   <script src="../js/popper.min.js" defer></script>
-  <script src="../js/bootstrap.min.js" defer></script>
+  <script src="../js/bootstrap.min.js"></script>
   <script src="../js/lightgallery-all.min.js" defer></script>
   <script src="../js/jquery.magnific-popup.min.js" defer></script>
   <script src="../js/aos.js" defer></script>

--- a/gallery_html/donna_nook.html
+++ b/gallery_html/donna_nook.html
@@ -129,11 +129,11 @@
   </div>
 
   <!-- for lateral navbar-->
-  <script src="../js/jquery-3.3.1.min.js" defer></script>
-  <script src="../js/jquery-migrate-3.0.1.min.js" defer></script>
+  <script src="../js/jquery-3.3.1.min.js"></script>
+  <script src="../js/jquery-migrate-3.0.1.min.js"></script>
   <script src="../js/jquery-ui.js" defer></script>
   <script src="../js/popper.min.js" defer></script>
-  <script src="../js/bootstrap.min.js" defer></script>
+  <script src="../js/bootstrap.min.js"></script>
   <script src="../js/owl.carousel.min.js" defer></script>
   <script src="../js/lightgallery-all.min.js" defer></script>
   <script src="../js/jquery.magnific-popup.min.js" defer></script>

--- a/gallery_html/iceland.html
+++ b/gallery_html/iceland.html
@@ -126,11 +126,11 @@
 
   </div>
   <!-- for lateral navbar-->
-  <script src="../js/jquery-3.3.1.min.js" defer></script>
-  <script src="../js/jquery-migrate-3.0.1.min.js" defer></script>
+  <script src="../js/jquery-3.3.1.min.js"></script>
+  <script src="../js/jquery-migrate-3.0.1.min.js"></script>
   <script src="../js/jquery-ui.js" defer></script>
   <script src="../js/popper.min.js" defer></script>
-  <script src="../js/bootstrap.min.js" defer></script>
+  <script src="../js/bootstrap.min.js"></script>
   <script src="../js/owl.carousel.min.js"></script>
   <script src="../js/jquery.magnific-popup.min.js" defer></script>
   <script src="../js/lightgallery-all.min.js" defer></script>

--- a/gallery_html/india.html
+++ b/gallery_html/india.html
@@ -127,11 +127,11 @@
   </div>
 
   <!-- for lateral navbar-->
-  <script src="../js/jquery-3.3.1.min.js" defer></script>
-  <script src="../js/jquery-migrate-3.0.1.min.js" defer></script>
+  <script src="../js/jquery-3.3.1.min.js"></script>
+  <script src="../js/jquery-migrate-3.0.1.min.js"></script>
   <script src="../js/jquery-ui.js" defer></script>
   <script src="../js/popper.min.js" defer></script>
-  <script src="../js/bootstrap.min.js" defer></script>
+  <script src="../js/bootstrap.min.js"></script>
   <script src="../js/owl.carousel.min.js"></script>
   <script src="../js/jquery.magnific-popup.min.js" defer></script>
   <script src="../js/lightgallery-all.min.js" defer></script>

--- a/gallery_html/japan.html
+++ b/gallery_html/japan.html
@@ -127,13 +127,13 @@
   </div>
 
   <!-- for lateral navbar-->
-	<script src="../assets/js/jquery-2.1.1.min.js" defer></script>
-  <script src="../assets/js/bootstrap.min.js" defer></script>
-  <script src="../js/jquery-3.3.1.min.js" defer></script>
-  <script src="../js/jquery-migrate-3.0.1.min.js" defer></script>
+	<script src="../assets/js/jquery-2.1.1.min.js"></script>
+  <script src="../assets/js/bootstrap.min.js"></script>
+  <script src="../js/jquery-3.3.1.min.js"></script>
+  <script src="../js/jquery-migrate-3.0.1.min.js"></script>
   <script src="../js/jquery-ui.js" defer></script>
   <script src="../js/popper.min.js" defer></script>
-  <script src="../js/bootstrap.min.js" defer></script>
+  <script src="../js/bootstrap.min.js"></script>
   <script src="../js/owl.carousel.min.js" defer></script>
   <script src="../js/jquery.stellar.min.js" defer></script>
   <script src="../js/jquery.countdown.min.js" defer></script>
@@ -145,16 +145,19 @@
   <script src="../js/picturefill.min.js" defer></script>
   <script src="../js/lightgallery-all.min.js" defer></script>
   <script src="../js/jquery.mousewheel.min.js" defer></script>
-  <script src="../js/dynamic-gallery.js" defer></script>
+  <script src="../js/dynamic-gallery.js"></script>
 
   <script src="../js/main.js"></script>
 
   <script>
-    initializeDynamicGallery(
-      '#lightgallery',
+    $(document).ready(function() {
+      initializeDynamicGallery(
+        '#lightgallery',
       'https://riccardopictures.zrok.lcas.group/Japan/',
       'Japan'
-    );
+    
+      );
+    });
   </script>
 
   <script>

--- a/gallery_html/langford_lowfields.html
+++ b/gallery_html/langford_lowfields.html
@@ -130,11 +130,11 @@
 	<script src="../assets/js/jquery-2.1.1.min.js"></script> 
   <script src="../assets/js/bootstrap.min.js"></script>
   
-  <script src="../js/jquery-3.3.1.min.js" defer></script>
-  <script src="../js/jquery-migrate-3.0.1.min.js" defer></script>
+  <script src="../js/jquery-3.3.1.min.js"></script>
+  <script src="../js/jquery-migrate-3.0.1.min.js"></script>
   <script src="../js/jquery-ui.js" defer></script>
   <script src="../js/popper.min.js" defer></script>
-  <script src="../js/bootstrap.min.js" defer></script>
+  <script src="../js/bootstrap.min.js"></script>
   <script src="../js/owl.carousel.min.js"></script>
   <script src="../js/jquery.stellar.min.js"></script>
   <script src="../js/jquery.countdown.min.js"></script>

--- a/gallery_html/norway.html
+++ b/gallery_html/norway.html
@@ -127,11 +127,11 @@
   </div>
 
   <!-- for lateral navbar-->
-  <script src="../js/jquery-3.3.1.min.js" defer></script>
-  <script src="../js/jquery-migrate-3.0.1.min.js" defer></script>
+  <script src="../js/jquery-3.3.1.min.js"></script>
+  <script src="../js/jquery-migrate-3.0.1.min.js"></script>
   <script src="../js/jquery-ui.js" defer></script>
   <script src="../js/popper.min.js" defer></script>
-  <script src="../js/bootstrap.min.js" defer></script>
+  <script src="../js/bootstrap.min.js"></script>
   <script src="../js/jquery.magnific-popup.min.js" defer></script>
   <script src="../js/lightgallery-all.min.js" defer></script>
   <script src="../js/aos.js" defer></script>

--- a/gallery_html/paris.html
+++ b/gallery_html/paris.html
@@ -127,11 +127,11 @@
   </div>
 
   <!-- for lateral navbar-->
-  <script src="../js/jquery-3.3.1.min.js" defer></script>
-  <script src="../js/jquery-migrate-3.0.1.min.js" defer></script>
+  <script src="../js/jquery-3.3.1.min.js"></script>
+  <script src="../js/jquery-migrate-3.0.1.min.js"></script>
   <script src="../js/jquery-ui.js" defer></script>
   <script src="../js/popper.min.js" defer></script>
-  <script src="../js/bootstrap.min.js" defer></script>
+  <script src="../js/bootstrap.min.js"></script>
   <script src="../js/jquery.magnific-popup.min.js" defer></script>
   <script src="../js/lightgallery-all.min.js" defer></script>
   <script src="../js/aos.js" defer></script>

--- a/gallery_html/peak_district.html
+++ b/gallery_html/peak_district.html
@@ -127,11 +127,11 @@
   </div>
 
   <!-- for lateral navbar-->
-  <script src="../js/jquery-3.3.1.min.js" defer></script>
-  <script src="../js/jquery-migrate-3.0.1.min.js" defer></script>
+  <script src="../js/jquery-3.3.1.min.js"></script>
+  <script src="../js/jquery-migrate-3.0.1.min.js"></script>
   <script src="../js/jquery-ui.js" defer></script>
   <script src="../js/popper.min.js" defer></script>
-  <script src="../js/bootstrap.min.js" defer></script>
+  <script src="../js/bootstrap.min.js"></script>
   <script src="../js/owl.carousel.min.js"></script>
   <script src="../js/jquery.magnific-popup.min.js" defer></script>
   <script src="../js/lightgallery-all.min.js" defer></script>

--- a/gallery_html/porto.html
+++ b/gallery_html/porto.html
@@ -123,11 +123,11 @@
 
   </div>
   <!-- for lateral navbar-->
-  <script src="../js/jquery-3.3.1.min.js" defer></script>
-  <script src="../js/jquery-migrate-3.0.1.min.js" defer></script>
+  <script src="../js/jquery-3.3.1.min.js"></script>
+  <script src="../js/jquery-migrate-3.0.1.min.js"></script>
   <script src="../js/jquery-ui.js" defer></script>
   <script src="../js/popper.min.js" defer></script>
-  <script src="../js/bootstrap.min.js" defer></script>
+  <script src="../js/bootstrap.min.js"></script>
   <script src="../js/jquery.magnific-popup.min.js" defer></script>
   <script src="../js/owl.carousel.min.js"></script>
   <script src="../js/lightgallery-all.min.js" defer></script>

--- a/gallery_html/rome.html
+++ b/gallery_html/rome.html
@@ -127,13 +127,13 @@
   </div>
 
   <!-- for lateral navbar-->
-	<script src="../assets/js/jquery-2.1.1.min.js" defer></script>
-  <script src="../assets/js/bootstrap.min.js" defer></script>
-  <script src="../js/jquery-3.3.1.min.js" defer></script>
-  <script src="../js/jquery-migrate-3.0.1.min.js" defer></script>
+	<script src="../assets/js/jquery-2.1.1.min.js"></script>
+  <script src="../assets/js/bootstrap.min.js"></script>
+  <script src="../js/jquery-3.3.1.min.js"></script>
+  <script src="../js/jquery-migrate-3.0.1.min.js"></script>
   <script src="../js/jquery-ui.js" defer></script>
   <script src="../js/popper.min.js" defer></script>
-  <script src="../js/bootstrap.min.js" defer></script>
+  <script src="../js/bootstrap.min.js"></script>
   <script src="../js/owl.carousel.min.js" defer></script>
   <script src="../js/jquery.stellar.min.js" defer></script>
   <script src="../js/jquery.countdown.min.js" defer></script>
@@ -145,16 +145,19 @@
   <script src="../js/picturefill.min.js" defer></script>
   <script src="../js/lightgallery-all.min.js" defer></script>
   <script src="../js/jquery.mousewheel.min.js" defer></script>
-  <script src="../js/dynamic-gallery.js" defer></script>
+  <script src="../js/dynamic-gallery.js"></script>
 
   <script src="../js/main.js"></script>
 
   <script>
-    initializeDynamicGallery(
-      '#lightgallery',
+    $(document).ready(function() {
+      initializeDynamicGallery(
+        '#lightgallery',
       'https://riccardopictures.zrok.lcas.group/Rome/',
       'Rome'
-    );
+    
+      );
+    });
   </script>
 
   <script>

--- a/gallery_html/sanfrancisco.html
+++ b/gallery_html/sanfrancisco.html
@@ -126,13 +126,13 @@
 
   </div>
   <!-- for lateral navbar-->
-<script src="../assets/js/jquery-2.1.1.min.js" defer></script>
-  <script src="../assets/js/bootstrap.min.js" defer></script>
-  <script src="../js/jquery-3.3.1.min.js" defer></script>
-  <script src="../js/jquery-migrate-3.0.1.min.js" defer></script>
+<script src="../assets/js/jquery-2.1.1.min.js"></script>
+  <script src="../assets/js/bootstrap.min.js"></script>
+  <script src="../js/jquery-3.3.1.min.js"></script>
+  <script src="../js/jquery-migrate-3.0.1.min.js"></script>
   <script src="../js/jquery-ui.js" defer></script>
   <script src="../js/popper.min.js" defer></script>
-  <script src="../js/bootstrap.min.js" defer></script>
+  <script src="../js/bootstrap.min.js"></script>
   <script src="../js/owl.carousel.min.js" defer></script>
   <script src="../js/jquery.stellar.min.js" defer></script>
   <script src="../js/jquery.countdown.min.js" defer></script>
@@ -144,16 +144,19 @@
   <script src="../js/picturefill.min.js" defer></script>
   <script src="../js/lightgallery-all.min.js" defer></script>
   <script src="../js/jquery.mousewheel.min.js" defer></script>
-  <script src="../js/dynamic-gallery.js" defer></script>
+  <script src="../js/dynamic-gallery.js"></script>
 
   <script src="../js/main.js"></script>
 
   <script>
-    initializeDynamicGallery(
-      '#lightgallery',
+    $(document).ready(function() {
+      initializeDynamicGallery(
+        '#lightgallery',
       'https://riccardopictures.zrok.lcas.group/Sanfransisco/',
       'Sanfransisco'
-    );
+    
+      );
+    });
   </script>
 
   <script>

--- a/gallery_html/sicily.html
+++ b/gallery_html/sicily.html
@@ -127,11 +127,11 @@
   </div>
 
   <!-- for lateral navbar-->
-	<script src="../js/jquery-3.3.1.min.js" defer></script>
-  <script src="../js/jquery-migrate-3.0.1.min.js" defer></script>
+	<script src="../js/jquery-3.3.1.min.js"></script>
+  <script src="../js/jquery-migrate-3.0.1.min.js"></script>
   <script src="../js/jquery-ui.js" defer></script>
   <script src="../js/popper.min.js" defer></script>
-  <script src="../js/bootstrap.min.js" defer></script>
+  <script src="../js/bootstrap.min.js"></script>
   <script src="../js/owl.carousel.min.js"></script>
   <script src="../js/jquery.magnific-popup.min.js" defer></script>
   <script src="../js/lightgallery-all.min.js" defer></script>

--- a/gallery_html/tuscany.html
+++ b/gallery_html/tuscany.html
@@ -126,11 +126,11 @@
   </div>
 
   <!-- for lateral navbar-->
-  <script src="../js/jquery-3.3.1.min.js" defer></script>
-  <script src="../js/jquery-migrate-3.0.1.min.js" defer></script>
+  <script src="../js/jquery-3.3.1.min.js"></script>
+  <script src="../js/jquery-migrate-3.0.1.min.js"></script>
   <script src="../js/jquery-ui.js" defer></script>
   <script src="../js/popper.min.js" defer></script>
-  <script src="../js/bootstrap.min.js" defer></script>
+  <script src="../js/bootstrap.min.js"></script>
   <script src="../js/jquery.magnific-popup.min.js" defer></script>
   <script src="../js/lightgallery-all.min.js" defer></script>
   <script src="../js/aos.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
 	<script src="js/jquery-migrate-3.0.1.min.js"></script>
 	<script src="js/jquery-ui.js" defer></script>
 	<script src="js/popper.min.js" defer></script>
-	<script src="js/bootstrap.min.js" defer></script>
+	<script src="js/bootstrap.min.js"></script>
 	<script src="js/owl.carousel.min.js" defer></script>
 	<script src="js/jquery.stellar.min.js" defer></script>
 	<script src="js/jquery.countdown.min.js" defer></script>

--- a/photos.html
+++ b/photos.html
@@ -306,14 +306,14 @@
 
 
 		<!-- for lateral navbar-->
-	<script src="assets/js/jquery-2.1.1.min.js" defer></script>
-	<script src="assets/js/bootstrap.min.js" defer></script>
+	<script src="assets/js/jquery-2.1.1.min.js"></script>
+	<script src="assets/js/bootstrap.min.js"></script>
 
-	<script src="js/jquery-3.3.1.min.js" defer></script>
-	<script src="js/jquery-migrate-3.0.1.min.js" defer></script>
+	<script src="js/jquery-3.3.1.min.js"></script>
+	<script src="js/jquery-migrate-3.0.1.min.js"></script>
 	<script src="js/jquery-ui.js" defer></script>
 	<script src="js/popper.min.js" defer></script>
-	<script src="js/bootstrap.min.js" defer></script>
+	<script src="js/bootstrap.min.js"></script>
 	<script src="js/owl.carousel.min.js" defer></script>
 	<script src="js/jquery.stellar.min.js" defer></script>
 	<script src="js/jquery.countdown.min.js" defer></script>

--- a/projects.html
+++ b/projects.html
@@ -273,13 +273,13 @@
 	<!-- END WRAPPER -->
 
 	<!-- for lateral navbar-->
-	<script src="assets/js/jquery-2.1.1.min.js" defer></script>
-	<script src="assets/js/bootstrap.min.js" defer></script>
-	<script src="js/jquery-3.3.1.min.js" defer></script>
-	<script src="js/jquery-migrate-3.0.1.min.js" defer></script>
+	<script src="assets/js/jquery-2.1.1.min.js"></script>
+	<script src="assets/js/bootstrap.min.js"></script>
+	<script src="js/jquery-3.3.1.min.js"></script>
+	<script src="js/jquery-migrate-3.0.1.min.js"></script>
 	<script src="js/jquery-ui.js" defer></script>
 	<script src="js/popper.min.js" defer></script>
-	<script src="js/bootstrap.min.js" defer></script>
+	<script src="js/bootstrap.min.js"></script>
 	<script src="js/owl.carousel.min.js" defer></script>
 	<script src="js/jquery.stellar.min.js" defer></script>
 	<script src="js/jquery.countdown.min.js" defer></script>

--- a/publications.html
+++ b/publications.html
@@ -323,13 +323,13 @@
 	<!-- END WRAPPER -->
 
 	<!-- for lateral navbar-->
-	<script src="assets/js/jquery-2.1.1.min.js" defer></script>
-	<script src="assets/js/bootstrap.min.js" defer></script>
-	<script src="js/jquery-3.3.1.min.js" defer></script>
-	<script src="js/jquery-migrate-3.0.1.min.js" defer></script>
+	<script src="assets/js/jquery-2.1.1.min.js"></script>
+	<script src="assets/js/bootstrap.min.js"></script>
+	<script src="js/jquery-3.3.1.min.js"></script>
+	<script src="js/jquery-migrate-3.0.1.min.js"></script>
 	<script src="js/jquery-ui.js" defer></script>
 	<script src="js/popper.min.js" defer></script>
-	<script src="js/bootstrap.min.js" defer></script>
+	<script src="js/bootstrap.min.js"></script>
 	<script src="js/owl.carousel.min.js" defer></script>
 	<script src="js/jquery.stellar.min.js" defer></script>
 	<script src="js/jquery.countdown.min.js" defer></script>

--- a/teaching.html
+++ b/teaching.html
@@ -159,13 +159,13 @@
 	<!-- END WRAPPER -->
 
 	<!-- for lateral navbar-->
-	<script src="assets/js/jquery-2.1.1.min.js" defer></script>
-	<script src="assets/js/bootstrap.min.js" defer></script>
-	<script src="js/jquery-3.3.1.min.js" defer></script>
-	<script src="js/jquery-migrate-3.0.1.min.js" defer></script>
+	<script src="assets/js/jquery-2.1.1.min.js"></script>
+	<script src="assets/js/bootstrap.min.js"></script>
+	<script src="js/jquery-3.3.1.min.js"></script>
+	<script src="js/jquery-migrate-3.0.1.min.js"></script>
 	<script src="js/jquery-ui.js" defer></script>
 	<script src="js/popper.min.js" defer></script>
-	<script src="js/bootstrap.min.js" defer></script>
+	<script src="js/bootstrap.min.js"></script>
 	<script src="js/owl.carousel.min.js" defer></script>
 	<script src="js/jquery.stellar.min.js" defer></script>
 	<script src="js/jquery.countdown.min.js" defer></script>


### PR DESCRIPTION
- Remove defer from jQuery core libraries (required by inline scripts)
- Remove defer from Bootstrap core (required for layout)
- Remove defer from main.js and dynamic-gallery.js (critical initialization)
- Wrap gallery initialization in $(document).ready() for proper timing
- Fixes navigation missing and gallery images not loading

The defer attribute cannot be used on scripts that:
1. Are depended on by inline scripts (jQuery, Bootstrap)
2. Define functions called immediately by inline scripts (dynamic-gallery.js)
3. Initialize critical UI components early (main.js)

Performance optimizations (defer) are still applied to:
- jQuery plugins (jquery-ui, owl.carousel, etc.)
- lightgallery-all.min.js
- Other non-critical libraries